### PR TITLE
Python Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: goreleaser
+
+on:
+  push:
+    tags: ["*"]
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      # https://github.com/actions/checkout/issues/290
+      - run: git fetch --force --tags
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.18
+      - run: make schema
+      - uses: goreleaser/goreleaser-action@v2
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: make install_python_sdk
+      - run: python setup.py build sdist
+        working-directory: sdk/python
+      - uses: pypa/gh-action-pypi-publish@master
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          packages_dir: sdk/python/dist/

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ WORKING_DIR     := $(shell pwd)
 OS := $(shell uname)
 EMPTY_TO_AVOID_SED := ""
 
+VERSION ?= $(patsubst v%,%,$(shell git describe))
+
 prepare::
 	@if test -z "${NAME}"; then echo "NAME not set"; exit 1; fi
 	@if test -z "${REPOSITORY}"; then echo "REPOSITORY not set"; exit 1; fi
@@ -113,6 +115,12 @@ install_dotnet_sdk::
 	find . -name '*.nupkg' -print -exec cp -p {} ${WORKING_DIR}/nuget \;
 
 install_python_sdk::
+	rm -rf sdk/python
+	bin/pulumi-tfgen-materialize $(VERSION) python
+	cp README.md sdk/python/
+	cd sdk/python/ && \
+		sed -i.bak -e "s/0\.0\.0/$(VERSION)/g" setup.py && \
+		rm setup.py.bak
 
 install_go_sdk::
 


### PR DESCRIPTION
Mostly lifted from some of the other pulumi providers in the org([pulumi-docker-buildkit](https://github.com/MaterializeInc/pulumi-docker-buildkit/blob/master/.github/workflows/release.yml) and [pulumi-fivetran](https://github.com/MaterializeInc/pulumi-fivetran/blob/master/.github/workflows/release.yml)). Limiting this to python which I have tested locally though the SDKs are built for the other languages as well.

To Do:
- [ ] Will need to set the `PYPI_API_TOKEN` as a secret in the repo.