### PR TITLE
Limit Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,5 @@ updates:
       interval: weekly
       day: sunday
       time: "22:00"
+    allow:
+      - dependency-name: "terraform-provider-materialize"


### PR DESCRIPTION
Limit Dependabot to only look for updates with the underlying terraform-provider-materialize module