### PR TITLE
Update 0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG
 =========
 
+## 0.1.3 - 2024-02-02
+Update to Terraform Provider [0.6.3](https://github.com/MaterializeInc/terraform-provider-materialize/releases/tag/v0.6.3).
+
 ## 0.1.2 - 2024-02-01
 Update to Terraform Provider [0.6.1](https://github.com/MaterializeInc/terraform-provider-materialize/releases/tag/v0.6.1).
 

--- a/provider/cmd/pulumi-resource-materialize/schema.json
+++ b/provider/cmd/pulumi-resource-materialize/schema.json
@@ -53,6 +53,15 @@
     },
     "config": {
         "variables": {
+            "baseEndpoint": {
+                "type": "string",
+                "description": "The base endpoint for Materialize.\n",
+                "defaultInfo": {
+                    "environment": [
+                        "MZ_BASE_ENDPOINT"
+                    ]
+                }
+            },
             "cloudEndpoint": {
                 "type": "string",
                 "description": "The endpoint for the Materialize Cloud API.\n",
@@ -2603,6 +2612,10 @@
     "provider": {
         "description": "The provider type for the materialize package. By default, resources use package-wide configuration\nsettings, however an explicit `Provider` instance may be created and passed during resource\nconstruction to achieve fine-grained programmatic control over provider settings. See the\n[documentation](https://www.pulumi.com/docs/reference/programming-model/#providers) for more information.\n",
         "properties": {
+            "baseEndpoint": {
+                "type": "string",
+                "description": "The base endpoint for Materialize.\n"
+            },
             "cloudEndpoint": {
                 "type": "string",
                 "description": "The endpoint for the Materialize Cloud API.\n"
@@ -2630,6 +2643,15 @@
             }
         },
         "inputProperties": {
+            "baseEndpoint": {
+                "type": "string",
+                "description": "The base endpoint for Materialize.\n",
+                "defaultInfo": {
+                    "environment": [
+                        "MZ_BASE_ENDPOINT"
+                    ]
+                }
+            },
             "cloudEndpoint": {
                 "type": "string",
                 "description": "The endpoint for the Materialize Cloud API.\n",

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -5,7 +5,7 @@ go 1.18
 replace github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20230912190043-e6d96b3b8f7e
 
 require (
-	github.com/MaterializeInc/terraform-provider-materialize v0.6.1
+	github.com/MaterializeInc/terraform-provider-materialize v0.6.3
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.59.0
 	github.com/pulumi/pulumi/sdk/v3 v3.81.0
 )

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -715,8 +715,8 @@ github.com/Masterminds/semver/v3 v3.2.0/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYr
 github.com/Masterminds/sprig/v3 v3.2.1/go.mod h1:UoaO7Yp8KlPnJIYWTFkMaqPUYKTfGFPhxNuwnnxkKlk=
 github.com/Masterminds/sprig/v3 v3.2.3 h1:eL2fZNezLomi0uOLqjQoN6BfsDD+fyLtgbJMAj9n6YA=
 github.com/Masterminds/sprig/v3 v3.2.3/go.mod h1:rXcFaZ2zZbLRJv/xSysmlgIM1u11eBaRMhvYXJNkGuM=
-github.com/MaterializeInc/terraform-provider-materialize v0.6.1 h1:eoZ6FVAsIVcBLPAG4sqkwZnxEXDnSMOeg04MnY8anQc=
-github.com/MaterializeInc/terraform-provider-materialize v0.6.1/go.mod h1:aXyDOh5mtxAv7ZFJeuqmZoGmI1JABo05Qk4vgNeDK64=
+github.com/MaterializeInc/terraform-provider-materialize v0.6.3 h1:Rba/TrJw4DBLrTwWhw2cHbNoZecH+Ryx38BIocNW+Wk=
+github.com/MaterializeInc/terraform-provider-materialize v0.6.3/go.mod h1:aXyDOh5mtxAv7ZFJeuqmZoGmI1JABo05Qk4vgNeDK64=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5/go.mod h1:tTuCMEN+UleMWgg9dVx4Hu52b1bJo+59jBh3ajtinzw=

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -77,6 +77,9 @@ func Provider() tfbridge.ProviderInfo {
 			"cloud_endpoint": {
 				Default: &tfbridge.DefaultInfo{EnvVars: []string{"MZ_CLOUD_ENDPOINT"}},
 			},
+			"base_endpoint": {
+				Default: &tfbridge.DefaultInfo{EnvVars: []string{"MZ_BASE_ENDPOINT"}},
+			},
 			"default_region": {
 				Default: &tfbridge.DefaultInfo{EnvVars: []string{"MZ_DEFAULT_REGION"}},
 			},


### PR DESCRIPTION
Preparing version `0.1.3` to ship the latest release of the TF backend [0.6.3](https://github.com/MaterializeInc/terraform-provider-materialize/releases/tag/v0.6.3)