### PR TITLE
Fix Failing Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,29 +14,31 @@ jobs:
     name: publish
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v3
-    # https://github.com/actions/checkout/issues/290
-    - run: git fetch --force --tags
-    - name: Install Go
-      uses: actions/setup-go@v4
-      with:
-        go-version: 1.21.x
-    - name: Install pulumictl
-      uses: jaxxstorm/action-install-gh-release@v1.5.0
-      with:
-        repo: pulumi/pulumictl
-    - name: Set PreRelease Version
-      run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)" >> $GITHUB_ENV
-    - name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@v2
-      with:
-        version: latest
-        args: -p 3 release --rm-dist
-    - name: Build Python SDK
-      run: make build_python
-    - name: Publish Python SDK
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}
-        packages_dir: sdk/python/bin/dist/
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      # https://github.com/actions/checkout/issues/290
+      - run: git fetch --force --tags
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.21.x
+      - name: Install pulumictl
+        uses: jaxxstorm/action-install-gh-release@v1.5.0
+        with:
+          repo: pulumi/pulumictl
+      - name: Set PreRelease Version
+        run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)" >> $GITHUB_ENV
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: -p 3 release --rm-dist
+      - name: Build Python SDK
+        run: make build_python
+      - name: Publish Python SDK
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          packages_dir: sdk/python/bin/dist/


### PR DESCRIPTION
Formatting the YAML file and also adding `fetch-depth: 0` as the CI is failing with:

```
  • getting and validating git state
    • couldn't find any tags before "v0.1.6"
    • git state                                      commit=9f77ea5c31609944014953322bbc30048d3f6da6 branch=HEAD current_tag=v0.1.6 previous_tag=<unknown> dirty=false
    • running against a shallow clone - check your CI documentation at https://goreleaser.com/ci
 ```