### PR TITLE
Disable telemetry in CI

### DIFF
--- a/examples/compose.yaml
+++ b/examples/compose.yaml
@@ -16,6 +16,8 @@ services:
       - --availability-zone=test1
       - --availability-zone=test2
       - --all-features
+    environment:
+      MZ_NO_TELEMETRY: 1
     ports:
       - 6875:6875
       - 6877:6877


### PR DESCRIPTION
As the Docker image now has telemetry enabled by default, we should disable this in all repos where we use it similar to: https://github.com/MaterializeInc/terraform-provider-materialize/pull/640