### PR TITLE
Update Go releaser version to 1.22

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.x
+          go-version: 1.22.x
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.5.0
         with:


### PR DESCRIPTION
The Terraform Provider now uses Go 1.22, but seems like I missed updating the go releaser workflow and the last release failed. This should fix it!