### PR TITLE
Add bootstrap-builtin-analytics-cluster-replica-size

### DIFF
--- a/examples/compose.yaml
+++ b/examples/compose.yaml
@@ -13,6 +13,7 @@ services:
       - --bootstrap-builtin-catalog-server-cluster-replica-size=3xsmall
       - --bootstrap-builtin-support-cluster-replica-size=3xsmall
       - --bootstrap-builtin-probe-cluster-replica-size=3xsmall
+      - --bootstrap-builtin-analytics-cluster-replica-size=3xsmall
       - --availability-zone=test1
       - --availability-zone=test2
       - --all-features


### PR DESCRIPTION
Adding `--bootstrap-builtin-analytics-cluster-replica-size=3xsmall` in order to fix the following panic with the latest materialzied image:

```
 Connection could not be recycled: Connection closed    
thread 'main' panicked at src/environmentd/src/bin/environmentd/main.rs:635:9:
environmentd: fatal: unknown cluster replica size '1'
   8: rust_begin_unwind
             at ./rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/std/src/panicking.rs:652:5
   9: core::panicking::panic_fmt
             at ./rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/core/src/panicking.rs:72:14
  10: environmentd::main
             at src/environmentd/src/bin/environmentd/main.rs:635:9
  11: <fn() as core::ops::function::FnOnce<()>>::call_once
             at ./rustc/3f5fd8dd41153bc5fdca9427e9e05be2c767ba23/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```