### PR TITLE
Deprecate repo: migrate to Pulumi "Any Terraform Provider" model

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,29 +1,62 @@
 # Contributing
 
-## Developing the provider
+> **⚠️ Repository Archived**
+>
+> **This repository is archived and no longer accepts contributions.**
+>
+> With Pulumi's new "Any Terraform Provider" framework, this separate provider repository is no longer needed. Users can now access the Materialize provider directly through the Terraform provider.
 
-The Pulumi provider is dependent on the [Terraform provider](https://github.com/MaterializeInc/terraform-provider-materialize). Any new features or changes should be applied there.
+## Where to Contribute Now
 
-### Updating Terraform provider
+### Terraform Provider (Main Development)
 
-To update the Terraform provider, change the version of `github.com/MaterializeInc/terraform-provider-materialize` in the [provider/go.mod](provider/go.mod) and run `go mod tidy`.
+All provider development now happens in the **Terraform provider repository**:
 
-> **Note**
-The repo is configured with dependabot to check for new versions of the Terraform provider.
+- **Repository**: [MaterializeInc/terraform-provider-materialize](https://github.com/MaterializeInc/terraform-provider-materialize)
+- **Issues**: [Report bugs and feature requests here](https://github.com/MaterializeInc/terraform-provider-materialize/issues)
+- **Pull Requests**: [Submit provider improvements here](https://github.com/MaterializeInc/terraform-provider-materialize/pulls)
 
-### Updating the schema
+### Pulumi Integration Issues
 
-To update the schema for the Pulumi provider (after the Terraform version has been updated) run `make tfgen` to automatically generate any new schema or property changes.
+For issues specific to the Pulumi integration or "Any Terraform Provider" framework:
 
-If a new resource or data source has been added, the reference will need to be added to [provider/resources.go]. After it has been added, you can run `make tfgen`.
+- **Pulumi Issues**: [pulumi/pulumi](https://github.com/pulumi/pulumi/issues)
+- **Pulumi 'Any Terraform Provider' Issues**: [pulumi/pulumi-terraform-provider](https://github.com/pulumi/pulumi-terraform-provider/issues)
+- **Community Support**: [Pulumi Community Slack](https://slack.pulumi.com/)
 
-## Cutting a release
+## How the New System Works
 
-To cut a new release of the provider, create a new tag and push that tag. This will trigger a Github Action to generate the artifacts and build the configured SDKs.
+The new Pulumi "Any Terraform Provider" framework automatically:
 
-```bash
-git tag vX.Y.Z
-git push origin vX.Y.Z
-```
+1. **Downloads the Terraform provider** from the HashiCorp registry
+2. **Generates Pulumi SDKs** locally in your project
+3. **Provides the same developer experience** as traditional Pulumi providers
+4. **Stays automatically up-to-date** with Terraform provider releases
 
-[Materialize]: https://materialize.com
+This eliminates the need for:
+- Separate Pulumi provider repositories
+- Manual SDK generation and publishing
+- Version synchronization between Terraform and Pulumi providers
+- Maintenance overhead for multiple language SDKs
+
+## Migration for Contributors
+
+If you were a contributor to this repository:
+
+### For Provider Features and Bug Fixes
+**Contribute to the Terraform provider instead:**
+- All provider logic, resources, and data sources are defined there
+- Changes automatically become available to Pulumi users as new versions are released
+
+## Historical Context
+
+This repository previously:
+1. **Bridged** the Terraform provider to Pulumi using the Pulumi Terraform Bridge
+2. **Generated and published** Only the Python SDK
+3. **Managed releases** and version synchronization
+
+The new approach provides all these benefits automatically without requiring separate repositories or maintenance.
+
+---
+
+**For all future contributions, please visit**: [MaterializeInc/terraform-provider-materialize](https://github.com/MaterializeInc/terraform-provider-materialize)

--- a/README.md
+++ b/README.md
@@ -2,53 +2,169 @@
 
 [![Slack Badge](https://img.shields.io/badge/Join%20us%20on%20Slack!-blueviolet?style=flat&logo=slack&link=https://materialize.com/s/chat)](https://materialize.com/s/chat)
 
-A [Pulumi](https://pulumi.com) provider for managing resources in a [Materialize](https://materialize.com/) account.
+> **⚠️ DEPRECATED - Repository Archived**
+>
+> **This repository is now archived and will no longer receive updates.** 
+>
+> With Pulumi's new "Any Terraform Provider" framework (released August 2024), you can now use the Materialize Terraform provider directly with Pulumi without needing this separate repository. This provides instant access to the latest provider features and eliminates maintenance overhead.
+>
+> **Please migrate to the new approach below**
+>
+> For any questions or help with migration, please reach out on the [Materialize Slack](https://materialize.com/s/chat) or via email at `support@materialize.com`.
 
-## Installing
+## 🚀 New Usage (Recommended)
 
-### Python
+As of **Pulumi CLI 3.130.0+**, you can use the Materialize provider directly without installing a separate package:
 
-To use from Python, install using `pip`:
+### Quick Start
 
 ```bash
-pip install pulumi_materialize
+# Create a new Pulumi project (if you haven't already)
+pulumi new python  # or typescript, go, etc.
+
+# Add the Materialize provider to your Pulumi project
+pulumi package add terraform-provider MaterializeInc/materialize
+
+# Or pin to a specific version:
+# pulumi package add terraform-provider MaterializeInc/materialize 0.9.1
 ```
+
+This commands automatically:
+- Generates a Pulumi SDK in your project
+- Download the Terraform provider
+- Configures your `Pulumi.yaml`
+- Provides full type safety and IntelliSense
+
+### Usage Examples
+
+**Python:**
+```python
+import pulumi_materialize as materialize
+
+# Create a database
+database = materialize.Database("my-db",
+    name="pulumi-created-db"
+)
+
+# Create a cluster 
+cluster = materialize.Cluster("my-cluster",
+    name="pulumi-cluster",
+    size="25cc"
+)
+```
+
+**TypeScript:**
+```typescript
+import * as materialize from "./sdks/materialize";
+
+const database = new materialize.Database("my-db", {
+    name: "production-db"
+});
+```
+
+**Go:**
+```go
+import "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+import materialize "./sdks/materialize"
+
+database, err := materialize.NewDatabase(ctx, "my-db", &materialize.DatabaseArgs{
+    Name: pulumi.String("production-db"),
+})
+```
+
+### Requirements
+
+- You will need to be using a version of Pulumi >= `3.147.0`.
+- No additional setup required!
 
 ## Configuration
 
-The following configuration points are available for the `materialize` provider:
+The configuration remains the same. Set these values using `pulumi config` or environment variables:
 
-- `materialize:password` (environment: `MZ_PASSWORD`) - Materialize password.
+- `materialize:password` (environment: `MZ_PASSWORD`) - Materialize password. Required for authentication.
+- `materialize:database` (environment: `MZ_DATABASE`) - Materialize database. Default is `materialize`.
+- `materialize:default_region` (environment: `MZ_DEFAULT_REGION`) - The default region if not specified in the resource. Default is `aws/us-east-1`.
+
+For self-hosted Materialize instances, you should also configure:
+
+- `materialize:host` (environment: `MZ_HOST`) - The hostname of your Materialize instance.
+- `materialize:port` (environment: `MZ_PORT`) - The port of your Materialize instance (default is 6875).
+
+Optional configurations for testing only:
+
 - `materialize:endpoint` (environment: `MZ_ENDPOINT`) - The endpoint for the Frontegg API.
 - `materialize:cloud_endpoint` (environment: `MZ_CLOUD_ENDPOINT`) - The endpoint for the Materialize Cloud API.
-- `materialize:default_region` (environment: `MZ_DEFAULT_REGION`) - The default region if not specified in the resource.
-- `materialize:database` (environment: `MZ_DATABASE`) - Materialize database.
 
-## Testing
-
-To run the tests which will simulate running Pulumi you will need to set the necessary envrionment variables and start the docker compose:
-
+**Example configuration:**
 ```bash
-export MZ_ENDPOINT=http://localhost:3000
-export MZ_CLOUD_ENDPOINT=http://localhost:3001
-export MZ_PASSWORD=mzp_1b2a3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b
-export MZ_SSLMODE=disable
-
-# Start all containers
-docker compose -f examples/compose.yaml up -d --build
+pulumi config set materialize:password "your-password" --secret
+pulumi config set materialize:database "your-database"
+pulumi config set materialize:default_region "aws/us-west-2"
 ```
 
-The tests also assume that the SDKs have been built and are present at `sdk/{SDK language}`. These are not committed to git but can be built locally by running `make build_{sdk}`.
+## Migration Guide
 
-You can then run the tests:
+### From Legacy Pulumi Package
 
+If you were using the legacy `pulumi_materialize` package:
+
+1. **Remove the old package:**
+   ```bash
+   # Python
+   pip uninstall pulumi_materialize
+   ```
+
+2. **Add the new provider:**
+   ```bash
+   pulumi package add terraform-provider MaterializeInc/materialize
+   ```
+
+3. **Update your imports:**
+   ```python
+   # Old
+   import pulumi_materialize as materialize
+
+   # New (same import, but now uses generated SDK)
+   import pulumi_materialize as materialize
+   ```
+
+4. **Verify your configuration** (no changes needed to config values)
+
+### Benefits of the New Approach
+
+- **Always up-to-date**: Automatically uses the latest Terraform provider
+- **Zero maintenance**: No waiting for Pulumi package updates
+- **Faster releases**: New Terraform provider features available immediately
+- **Better type safety**: Generated SDKs with full IntelliSense
+- **Smaller footprint**: No separate package installation required
+
+## Advanced Usage
+
+### Version Pinning
 ```bash
-make test
+# Pin to a specific provider version for reproducible builds
+pulumi package add terraform-provider MaterializeInc/materialize@0.9.1
 ```
 
-## Contributing
+### Local Development
+```bash
+# Use a local provider binary for development
+pulumi package add terraform-provider ./path/to/terraform-provider-materialize
+```
 
-Please see [CONTRIBUTING.md](CONTRIBUTING.md) for instructions on how to contribute to this provider.
+## Resources and Documentation
 
-> **Warning**
-> The provider is under active development.
+- **Materialize Terraform Provider**: [MaterializeInc/terraform-provider-materialize](https://github.com/MaterializeInc/terraform-provider-materialize)
+- **Pulumi "Any Terraform Provider" Docs**: [Pulumi Registry](https://www.pulumi.com/registry/packages/terraform-provider/)
+- **Materialize Documentation**: [materialize.com/docs](https://materialize.com/docs)
+- **Community Support**: [Materialize Slack](https://materialize.com/s/chat)
+
+## Need Help?
+
+- **Provider Issues**: Report at [terraform-provider-materialize](https://github.com/MaterializeInc/terraform-provider-materialize/issues)
+- **Pulumi Integration**: Check [Pulumi Community Slack](https://slack.pulumi.com/)
+- **Materialize Support**: Join [Materialize Slack](https://materialize.com/s/chat)
+
+---
+
+**This repository is archived.** All future development happens in the [Terraform provider](https://github.com/MaterializeInc/terraform-provider-materialize). Thank you for using the Materialize Pulumi provider!


### PR DESCRIPTION
Tested and verified that the "Any Terraform Provider" Pulumi model works well. However one thing to note here is that this new Pulumi integration is currently in **Public Beta** and may include breaking changes. See Pulumi's registry for details:

> https://www.pulumi.com/registry/packages/terraform-provider/

We can hold with the deprecation and archiving this repository until the package is stable?

Besides that, the PR just adds a deprecation message for the Pulumi Materialize provider in favor of Pulumi's new "Any Terraform Provider" support.

The README now guides users to use the Materialize Terraform provider directly via `pulumi package add`.

We can archive the repo after merging.
